### PR TITLE
fix: wrong symbols in v6.

### DIFF
--- a/symbols.js
+++ b/symbols.js
@@ -186,7 +186,7 @@ const v6 = {
         'napi_set_instance_data'
     ],
     node_api_symbols: [
-        ...v5.js_native_api_symbols
+        ...v5.node_api_symbols
     ]
 }
 


### PR DESCRIPTION
This PR fixes the issue https://github.com/nodejs/node-api-headers/issues/5.
