### PR TITLE
Add helper scripts for updating headers and symbols.js

### DIFF
--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -1,0 +1,52 @@
+name: Header Sync
+
+on:
+  workflow_dispatch: null
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Update headers from nodejs/node
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - shell: bash
+        id: check-changes
+        name: Check Changes
+        run: |
+          COMMIT_MESSAGE=$(npm run --silent update-headers)
+          VERSION=${COMMIT_MESSAGE##* }
+          echo $COMMIT_MESSAGE
+          npm run --silent write-symbols
+          CHANGED_FILES=$(git diff --name-only)
+          BRANCH_NAME="update-headers/${VERSION}"
+          if [ -z "$CHANGED_FILES" ]; then
+              echo "No changes exist. Nothing to do."
+          else
+              echo "Changes exist. Checking if branch exists: $BRANCH_NAME"
+              if git ls-remote --exit-code --heads $GITHUB_SERVER_URL/$GITHUB_REPOSITORY $BRANCH_NAME >/dev/null; then
+                  echo "Branch exists. Nothing to do."
+              else
+                  echo "Branch does not exists."
+                  echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
+                  echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
+              fi
+          fi
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        if: ${{ steps.check-changes.outputs.BRANCH_NAME }}
+        with:
+          branch: ${{ steps.check-changes.outputs.BRANCH_NAME }}
+          commit-message: ${{ steps.check-changes.outputs.COMMIT_MESSAGE }}
+          title: ${{ steps.check-changes.outputs.COMMIT_MESSAGE }}
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          body: null
+          delete-branch: true

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+scripts/

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 scripts/
+.github/

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "url": "git://github.com/nodejs/node-api-headers.git"
   },
   "scripts": {
+    "update-headers": "node --no-warnings scripts/update-headers.js",
+    "write-symbols": "node --no-warnings scripts/write-symbols.js"
   },
   "version": "0.0.2",
   "support": true

--- a/scripts/clang-utils.js
+++ b/scripts/clang-utils.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { spawn } = require('child_process');
+
+/**
+ * @param {Array<string>} [args]
+ * @returns {Promise<{exitCode: number | null, stdout: string, stderr: string}>}
+ */
+async function runClang(args = []) {
+    try {
+        const { exitCode, stdout, stderr } = await new Promise((resolve, reject) => {
+            const spawned = spawn('clang',
+                ['-Xclang', ...args]
+            );
+
+            let stdout = '';
+            let stderr = '';
+
+            spawned.stdout?.on('data', (data) => {
+                stdout += data.toString('utf-8');
+            });
+            spawned.stderr?.on('data', (data) => {
+                stderr += data.toString('utf-8');
+            });
+
+            spawned.on('exit', function (exitCode) {
+                resolve({ exitCode, stdout, stderr });
+            });
+
+            spawned.on('error', function (err) {
+                reject(err);
+            });
+        });
+
+        if (exitCode !== 0) {
+            throw new Error(`clang exited with non-zero exit code ${exitCode}. stderr: ${stderr ? stderr : '<empty>'}`);
+        }
+
+        return { exitCode, stdout, stderr };
+    } catch (err) {
+        if (err.code === 'ENOENT') {
+            throw new Error('This tool requires clang to be installed.');
+        }
+        throw err;
+    }
+}
+
+module.exports = {
+    runClang
+};

--- a/scripts/update-headers.js
+++ b/scripts/update-headers.js
@@ -2,18 +2,40 @@ const { createWriteStream } = require('fs');
 const { Readable } = require('stream');
 const { finished } = require('stream/promises');
 const { resolve } = require('path');
+const { parseArgs } = require('util')
 
-const files = ['js_native_api_types.h', 'js_native_api.h', 'node_api_types.h', 'node_api.h'];
-
-const commit = process.argv[2] ?? `${process.version.substring(0,3)}.x`;
-
-console.log(`Using commit ${commit}:`);
+async function getLatestReleaseVersion() {
+    const response = await fetch('https://nodejs.org/download/release/index.json');
+    const json = await response.json();
+    return json[0].version;
+}
 
 async function main() {
+    const { values: { tag, verbose } } = parseArgs({
+        options: {
+            tag: {
+                type: "string",
+                short: "t",
+                default: await getLatestReleaseVersion()
+            },
+            verbose: {
+                type: "boolean",
+                short: "v",
+            },
+        },
+    });
+
+    console.log(`Update headers from nodejs/node tag ${tag}`);
+
+    const files = ['js_native_api_types.h', 'js_native_api.h', 'node_api_types.h', 'node_api.h'];
+
     for (const filename of files) {
-        const url = `https://raw.githubusercontent.com/nodejs/node/${commit}/src/${filename}`;
+        const url = `https://raw.githubusercontent.com/nodejs/node/${tag}/src/${filename}`;
         const path = resolve(__dirname, '..', 'include', filename);
-        console.log(`  ${url} -> ${path}`);
+
+        if (verbose) {
+            console.log(`  ${url} -> ${path}`);
+        }
 
         const response = await fetch(url);
         if (!response.ok) {

--- a/scripts/update-headers.js
+++ b/scripts/update-headers.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { createWriteStream } = require('fs');
 const { Readable } = require('stream');
 const { finished } = require('stream/promises');

--- a/scripts/update-headers.js
+++ b/scripts/update-headers.js
@@ -5,7 +5,7 @@ const { resolve } = require('path');
 
 const files = ['js_native_api_types.h', 'js_native_api.h', 'node_api_types.h', 'node_api.h'];
 
-const commit = process.argv[2] ?? 'main';
+const commit = process.argv[2] ?? `${process.version.substring(0,3)}.x`;
 
 console.log(`Using commit ${commit}:`);
 

--- a/scripts/update-headers.js
+++ b/scripts/update-headers.js
@@ -1,0 +1,31 @@
+const { createWriteStream } = require('fs');
+const { Readable } = require('stream');
+const { finished } = require('stream/promises');
+const { resolve } = require('path');
+
+const files = ['js_native_api_types.h', 'js_native_api.h', 'node_api_types.h', 'node_api.h'];
+
+const commit = process.argv[2] ?? 'main';
+
+console.log(`Using commit ${commit}:`);
+
+async function main() {
+    for (const filename of files) {
+        const url = `https://raw.githubusercontent.com/nodejs/node/${commit}/src/${filename}`;
+        const path = resolve(__dirname, '..', 'include', filename);
+        console.log(`  ${url} -> ${path}`);
+
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`Fetch of ${url} returned ${response.status} ${response.statusText}`);
+        }
+
+        const stream = createWriteStream(path);
+        await finished(Readable.fromWeb(response.body).pipe(stream));
+    }
+}
+
+main().catch(e => {
+    console.error(e);
+    process.exitCode = 1;
+});

--- a/scripts/write-symbols.js
+++ b/scripts/write-symbols.js
@@ -1,0 +1,144 @@
+const { spawnSync } = require('child_process');
+const { resolve } = require('path');
+const { writeFileSync } = require('fs');
+
+function getSymbolsForVersion(version) {
+    const spawned = spawnSync('clang',
+        ['-Xclang', '-ast-dump=json', '-fsyntax-only', '-fno-diagnostics-color', version ? `-DNAPI_VERSION=${version}` : '-DNAPI_EXPERIMENTAL', resolve(__dirname, '..', 'include', 'node_api.h')],
+        { maxBuffer: 2_000_000 }
+    );
+
+    if (spawned.error) {
+        if (spawned.error.code === 'ENOENT') {
+            throw new Error('This tool requires clang to be installed.');
+        }
+        throw spawned.error;
+    } else if (spawned.stderr.length > 0) {
+        throw new Error(spawned.stderr.toString('utf-8'));
+    }
+
+    const ast = JSON.parse(spawned.stdout.toString('utf-8'));
+    const symbols = { js_native_api_symbols: [], node_api_symbols: [] };
+
+    for (const statement of ast.inner) {
+        if (statement.kind !== 'FunctionDecl') {
+            continue;
+        }
+
+        const name = statement.name;
+        const file = statement.loc.includedFrom?.file;
+
+        if (file) {
+            symbols.js_native_api_symbols.push(name);
+        } else {
+            symbols.node_api_symbols.push(name);
+        }
+    }
+
+    symbols.js_native_api_symbols.sort();
+    symbols.node_api_symbols.sort();
+
+    return symbols;
+}
+
+
+function getAllSymbols() {
+    const allSymbols = {};
+    let version = 1;
+
+    console.log('Processing symbols from clang:')
+    while (true) {
+        const symbols = getSymbolsForVersion(version);
+
+        if (version > 1) {
+            const previousSymbols = allSymbols[`v${version - 1}`];
+            if (previousSymbols.js_native_api_symbols.length == symbols.js_native_api_symbols.length && previousSymbols.node_api_symbols.length === symbols.node_api_symbols.length) {
+                --version;
+                break;
+            }
+        }
+        allSymbols[`v${version}`] = symbols;
+        console.log(`  v${version}: ${symbols.js_native_api_symbols.length} js_native_api_symbols, ${symbols.node_api_symbols.length} node_api_symbols`);
+        ++version;
+    }
+
+    const symbols = allSymbols[`experimental`] = getSymbolsForVersion();
+    console.log(`  Experimental: ${symbols.js_native_api_symbols.length} js_native_api_symbols, ${symbols.node_api_symbols.length} node_api_symbols`);
+    return {
+        maxVersion: version,
+        symbols: allSymbols
+    };
+}
+
+function getUniqueSymbols(previousSymbols, currentSymbols) {
+    const symbols = { js_native_api_symbols: [], node_api_symbols: [] };
+    for (const symbol of currentSymbols.js_native_api_symbols) {
+        if (!previousSymbols.js_native_api_symbols.includes(symbol)) {
+            symbols.js_native_api_symbols.push(symbol);
+        }
+    }
+    for (const symbol of currentSymbols.node_api_symbols) {
+        if (!previousSymbols.node_api_symbols.includes(symbol)) {
+            symbols.node_api_symbols.push(symbol);
+        }
+    }
+    return symbols;
+}
+
+function joinSymbols(symbols, prependNewLine) {
+    if (symbols.length === 0) return '';
+    return `${prependNewLine ? ',\n        ' : ''}'${symbols.join("',\n        '")}'`;
+}
+
+function getSymbolData() {
+    const { maxVersion, symbols } = getAllSymbols();
+
+    let data = `'use strict'
+
+const v1 = {
+    js_native_api_symbols: [
+        ${joinSymbols(symbols.v1.js_native_api_symbols)}
+    ],
+    node_api_symbols: [
+        ${joinSymbols(symbols.v1.node_api_symbols)}
+    ]
+}
+`;
+
+    for (let version = 2; version <= maxVersion + 1; ++version) {
+        const newSymbols = getUniqueSymbols(symbols[`v${version - 1}`], symbols[version === maxVersion + 1 ? 'experimental' : `v${version}`]);
+
+        data += `
+const ${version === maxVersion + 1 ? 'experimental' : `v${version}`} = {
+    js_native_api_symbols: [
+        ...v${version - 1}.js_native_api_symbols${joinSymbols(newSymbols.js_native_api_symbols, true)}
+    ],
+    node_api_symbols: [
+        ...v${version - 1}.node_api_symbols${joinSymbols(newSymbols.node_api_symbols, true)}
+    ]
+}
+`;
+    }
+
+    data += `
+module.exports = {
+    ${new Array(maxVersion).fill(undefined).map((_, i) => `v${i + 1}`).join(',\n    ')},
+    experimental
+}
+`
+    return data;
+}
+
+function main() {
+    const path = resolve(__dirname, '../symbols.js');
+    const data = getSymbolData();
+    console.log(`Writing symbols to ${path}`)
+    writeFileSync(path, data);
+}
+
+try {
+    main();
+} catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+}

--- a/scripts/write-symbols.js
+++ b/scripts/write-symbols.js
@@ -1,4 +1,3 @@
-// @ts-check
 'use strict';
 
 const { spawn } = require('child_process');
@@ -43,7 +42,7 @@ async function getSymbolsForVersion(version) {
 
         const ast = JSON.parse(stdout);
 
-        /** @type {{js_native_api_symbols: string[], node_api_symbols: string[]}} */
+        /** @type {SymbolInfo} */
         const symbols = { js_native_api_symbols: [], node_api_symbols: [] };
 
         for (const statement of ast.inner) {

--- a/scripts/write-symbols.js
+++ b/scripts/write-symbols.js
@@ -148,7 +148,7 @@ const v1 = {
         const newSymbols = getUniqueSymbols(symbols[`v${version - 1}`], symbols[`v${version}`]);
 
         data += `
-const ${`v${version}`} = {
+const v${version} = {
     js_native_api_symbols: [
         ...v${version - 1}.js_native_api_symbols${joinStrings(newSymbols.js_native_api_symbols, true)}
     ],


### PR DESCRIPTION
Added two new scripts runnable via `npm`:
- `npm run-script update-headers`: Fetch latest headers from nodejs/node and removes `NAPI_EXPERIMENTAL` preprocessor checks of `#ifdef` and `#ifndef`, assuming it is _not_ defined.
- `npm run-script write-symbols`: Use `clang` to process headers to create `symbols.js`

This PR also adds a GitHub Actions workflow for performing the sync on a daily schedule (also can be manually triggered).

Relates: #2 