### PR TITLE
fix: moved def files on a proper folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ The module exports two properties `include_dir` and `symbols`.
 This property is a string that represents the include path for the Node-API
 headers.
 
+### `def`
+
+This property is an object that has two keys `js_native_api_def` and
+`node_api_def` which represents the path of the module definition file for the
+`js_native_api` and `node_api` respectively.
+
 ### `symbols`
 
 This property is an object that represents the symbols exported by Node-API

--- a/index.js
+++ b/index.js
@@ -1,11 +1,17 @@
 'use strict'
 
 const path = require('path');
-const symbols = require('./symbols')
+const symbols = require('./symbols');
 
 const include_dir = path.resolve(__dirname, 'include');
+const defRoot = path.resolve(__dirname, 'def')
+const def = {
+    js_native_api_def: path.join(defRoot, 'js_native_api.def'),
+    node_api_def: path.join(defRoot, 'node_api.def')
+}
 
 module.exports = {
     include_dir,
+    def,
     symbols
 }

--- a/scripts/write-win32-def.js
+++ b/scripts/write-win32-def.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { resolve: resolvePath } = require('path');
-const { writeFile } = require('fs/promises');
+const { resolve: resolvePath, join: joinPath } = require('path');
+const { writeFile, mkdir } = require('fs/promises');
 const { symbols } = require('..');
 
 function getNodeApiDef() {
@@ -28,11 +28,20 @@ function getJsNativeApiDef() {
 }
 
 async function main() {
-    const nodeApiDefPath = resolvePath(__dirname, '../node_api.def');
+    const def = resolvePath(__dirname, '../def'); 
+    try {
+        await mkdir(def)
+    } catch (e) {
+        if (e.code !== 'EEXIST') {
+            throw e;
+        }
+    }
+   
+    const nodeApiDefPath = joinPath(def, 'node_api.def');
     console.log(`Writing Windows .def file to ${nodeApiDefPath}`);
     await writeFile(nodeApiDefPath, getNodeApiDef());
 
-    const jsNativeApiDefPath = resolvePath(__dirname, '../js_native_api.def');
+    const jsNativeApiDefPath = joinPath(def, 'js_native_api.def');
     console.log(`Writing Windows .def file to ${jsNativeApiDefPath}`);
     await writeFile(jsNativeApiDefPath, getJsNativeApiDef());
 }


### PR DESCRIPTION
This PR moved the definition files in a folder `def` and provide a way to obtain the path of the definition file by JavaScript.