### PR TITLE
Use `git status` instead of `git diff` for change calculation

### DIFF
--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -27,7 +27,7 @@ jobs:
           echo $COMMIT_MESSAGE
           npm run --silent write-symbols
           npm run --silent write-win32-def
-          CHANGED_FILES=$(git diff --name-only)
+          CHANGED_FILES=$(git status -s)
           BRANCH_NAME="update-headers/${VERSION}"
           if [ -z "$CHANGED_FILES" ]; then
               echo "No changes exist. Nothing to do."


### PR DESCRIPTION
`git diff` does not list untracked files whereas `git status` does.