### PR TITLE
ci: update sync-headers to close old PRs, better PR text

### DIFF
--- a/.github/workflows/sync-headers.yml
+++ b/.github/workflows/sync-headers.yml
@@ -39,15 +39,28 @@ jobs:
                   echo "Branch does not exists."
                   echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
                   echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
+                  echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
               fi
           fi
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        id: cpr
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
         if: ${{ steps.check-changes.outputs.BRANCH_NAME }}
         with:
           branch: ${{ steps.check-changes.outputs.BRANCH_NAME }}
           commit-message: ${{ steps.check-changes.outputs.COMMIT_MESSAGE }}
           title: ${{ steps.check-changes.outputs.COMMIT_MESSAGE }}
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          body: null
+          body: Automated sync of headers with Node.js ${{ steps.check-changes.outputs.VERSION }}
+          labels: headers
           delete-branch: true
+      - name: Close existing PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          gh pr list --json number,author,title,labels  --jq '[ .[] | select(.author.login == "app/github-actions" and .number != ${{ steps.cpr.outputs.pull-request-number }} and (.labels[]| select(.name =="headers" )))]' | jq -c '.[]' |
+          while IFS=$"\n" read -r c; do
+              pr_number=$(echo "$c" | jq -r '.number')
+              gh pr close $pr_number --delete-branch --comment "Closing in favor of [#${{ steps.cpr.outputs.pull-request-number }}](${{ steps.cpr.outputs.pull-request-url }})."
+          done

--- a/scripts/update-headers.js
+++ b/scripts/update-headers.js
@@ -160,7 +160,7 @@ async function main() {
         },
     });
 
-    console.log(`Update headers from nodejs/node tag ${tag}`);
+    console.log(`feat: update headers from nodejs/node tag ${tag}`);
 
     const files = ['js_native_api_types.h', 'js_native_api.h', 'node_api_types.h', 'node_api.h'];
 


### PR DESCRIPTION
Update sync-headers CI action: 
- Use conventional commit `feat` tag
- Close old PRs when a new one comes up